### PR TITLE
Fix pixel gaps between maps

### DIFF
--- a/src/editor_widget.rs
+++ b/src/editor_widget.rs
@@ -75,8 +75,8 @@ impl EditorTransform {
     }
 
     fn point_level_to_screen(&self, x: i32, y: i32) -> (i32, i32) {
-        ((x - self.map_corner_x) * self.map_scale as i32 / 8,
-         (y - self.map_corner_y) * self.map_scale as i32 / 8)
+        (((x - self.map_corner_x) * self.map_scale as i32).div_euclid(8),
+         ((y - self.map_corner_y) * self.map_scale as i32).div_euclid(8))
     }
 }
 
@@ -338,7 +338,6 @@ impl EditorState {
         }
         room_buffer.as_ref().draw_clipped(clip_box, rect_screen.x, rect_screen.y);
     }
-
 }
 
 impl map_struct::Rect {


### PR DESCRIPTION
Need to use euclidean division or division above and below zero will round in different directions and result in a pixel gap when rendering. This kind of bug is why I hate that the default rounding for division is round towards zero.